### PR TITLE
Fix GetAuthSessionTicket error

### DIFF
--- a/addons/godotsteam_csharpbindings/Steam.User.cs
+++ b/addons/godotsteam_csharpbindings/Steam.User.cs
@@ -27,7 +27,7 @@ public static partial class Steam
         GetInstance().Call(Methods.EndAuthSession, steamId);
     }
     
-    public static Godot.Collections.Dictionary GetAuthSessionTicket(string identityReference = "")
+    public static Godot.Collections.Dictionary GetAuthSessionTicket(ulong identityReference = 0)
     {
         return GetInstance().Call(Methods.GetAuthSessionTicket, identityReference).AsGodotDictionary();
     }


### PR DESCRIPTION
I got an error when calling `Steam.GetAuthSessionTicket()` and it seems to be because the original GodotSteam method wants an ulong with default value of 0 instead of a string : https://github.com/GodotSteam/GodotSteam/blob/0528e1cd476824e593b62080836cbe4157d97ce3/godotsteam.h#L794

Here is a small PR fixing that.

Best regard,

Eole