### PR TITLE
Fix ExchangeItems types

### DIFF
--- a/addons/godotsteam_csharpbindings/Steam.Inventory.cs
+++ b/addons/godotsteam_csharpbindings/Steam.Inventory.cs
@@ -32,7 +32,7 @@ public static partial class Steam
         GetInstance().Call(Methods.DestroyResult, thisInventoryHandle);
     }
     
-    public static int ExchangeItems(long[] outputItems, uint outputQuantity, ulong inputItems, long inputQuantity)
+    public static int ExchangeItems(long[] outputItems, int[] outputQuantity, long[] inputItems, int[] inputQuantity)
     {
         return GetInstance().Call(Methods.ExchangeItems, outputItems, outputQuantity, inputItems, inputQuantity).As<int>();
     }


### PR DESCRIPTION
Hello, thanks for your work!

Was trying to use ExchangeItems and found that the types were not in line with [GodotSteam documentation](https://godotsteam.com/classes/inventory/?h=exchange#exchangeitems), with `PackedInt32Array` and `PackedInt64Array`