### PR TITLE
PATCH - GetSteamId Methods Type Correction [#55]

### DIFF
--- a/gluecode-project/addons/godotsteam_csharpbindings/Steam.cs
+++ b/gluecode-project/addons/godotsteam_csharpbindings/Steam.cs
@@ -7747,7 +7747,7 @@ public enum RemoteStoragePlatform
     public new string GetGodotsteamVersion() => 
         Call(GDExtensionMethodName.GetGodotsteamVersion, []).As<string>();
 
-    public new long GetSteamId32(long steamId) => 
+    public new long GetSteamId32(ulong steamId) =>
         Call(GDExtensionMethodName.GetSteamId32, [steamId]).As<long>();
 
     public new bool IsAnonAccount(long steamId) => 
@@ -9676,8 +9676,8 @@ public enum RemoteStoragePlatform
     public new long GetPlayerSteamLevel() => 
         Call(GDExtensionMethodName.GetPlayerSteamLevel, []).As<long>();
 
-    public new long GetSteamId() => 
-        Call(GDExtensionMethodName.GetSteamId, []).As<long>();
+    public new ulong GetSteamId() =>
+        Call(GDExtensionMethodName.GetSteamId, []).As<ulong>();
 
     public new Godot.Collections.Dictionary GetVoice(long bufferSizeOverride = 0) => 
         Call(GDExtensionMethodName.GetVoice, [bufferSizeOverride]).As<Godot.Collections.Dictionary>();

--- a/godotsteam-patcher/patches/031-get-steam-id-methods.json
+++ b/godotsteam-patcher/patches/031-get-steam-id-methods.json
@@ -1,0 +1,26 @@
+{
+  "id": "steam-id-type-update",
+  "operations": [
+	{
+      "op": "replaceLine",
+      "id": "update-GetSteamId32-method",
+      "pattern": "public new long GetSteamId32(long steamId) =>",
+      "code": "public new long GetSteamId32(ulong steamId) =>",
+      "skipIfPresent": true
+    },
+    {
+      "op": "replaceBetween",
+      "id": "update-GetSteamId-method",
+      "start": "public new long GetSteamId() =>",
+      "end": ";",
+      "includeStart": true,
+      "includeEnd": true,
+      "useRegex": false,
+      "caseInsensitive": false,
+      "code": [
+		"public new ulong GetSteamId() =>",
+		"    Call(GDExtensionMethodName.GetSteamId, []).As<ulong>();"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Created a new patch to address issue #55.

The patch uses single line replacement for `GetSteamId32` since the return type is still `long`.

Replace between is used for `GetSteamId` since both lines need updated.

No errors present when I tested usage of both methods after the patch by modifying the `Test001` scene to also print the id.

Closed #56 due to bad pull hygiene. I was unaware that a branch with an open PR will get all commits placed on that branch while the PR is open, so I polluted the old PR on accident. Lesson learned.